### PR TITLE
README: Point to the docs built by GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ This package contains the documentation for the PAM ROBOT Software (Ubuntu only)
 
 The software contains the packages (c++ with python wrappers) for controlling environment(s) containing (real or mujoco simulated) pneumatic artificial muscles robot(s), ball(s) and table (to get the robots to play table tennis).
 
-See this [documentation online](http://people.tuebingen.mpg.de/mpi-is-software/pam/docs/), along with the source and binaries tar balls: [http://people.tuebingen.mpg.de/mpi-is-software/pam/](http://people.tuebingen.mpg.de/mpi-is-software/pam/).
+See this [documentation online](https://intelligent-soft-robots.github.io/pam_documentation), along with the source and binaries tar balls: [http://people.tuebingen.mpg.de/mpi-is-software/pam/](http://people.tuebingen.mpg.de/mpi-is-software/pam/).
 


### PR DESCRIPTION
## Description
Update the link to the documentation to point to the one that is
automatically built by GitHub.


## How I Tested

Viewed the modified file on GitHub.