### PR TITLE
Fix broken links and an indentation issue

### DIFF
--- a/A1_overview_and_installation.md
+++ b/A1_overview_and_installation.md
@@ -31,7 +31,7 @@ The command above spawns a "backend" process which connects to the robot. This p
 
 User may then use a python (or a c++) API for interacting with the shared memory, i.e. reading the state of the robot (written by the backend) or writing commands to it (which will then be read by the backend and applied to the robot).
 
-There are quite a few types of commands that can be written in the shared memory. The system is based on o80, and it is advised to read o80's [documentation](http://people.tuebingen.mpg.de/mpi-is-software/o80/docs/o80/index.html) before going further.
+There are quite a few types of commands that can be written in the shared memory. The system is based on o80, and it is advised to read o80's {doc}`documentation <o80:index>` before going further.
 
 ## Software installation 
 

--- a/A1_overview_and_installation.md
+++ b/A1_overview_and_installation.md
@@ -94,6 +94,9 @@ sudo ldconfig
 
 Copy your mujoco key (mjkey.txt) in /opt/mujoco.
 
+
+(install_via_colcon)=
+
 ### Via colcon workspace
 
 This is the recommanded way for developpers of the PAM software (as opposed to the users of it).

--- a/C2_real_robot.md
+++ b/C2_real_robot.md
@@ -149,7 +149,7 @@ pam_check 0
 
 ## Method 2: O80 PAM
 
-o80_real is a wrappers over [pam_interface](https://intelligent-soft-robots.github.io/code_documentation/pam_interface/docs/html/index.html) providing [o80](https://intelligent-soft-robots.github.io/code_documentation/o80/docs/html/index.html) functionalities.
+o80_real is a wrappers over [pam_interface](https://github.com/intelligent-soft-robots/pam_interface) providing {doc}`o80 <o80:index>` functionalities.
 
 This documentation assumes you are familiar with both *pam_interface* and *o80*.
 
@@ -169,7 +169,7 @@ To start a server over a dummy robot (no real physics, no graphics, just for deb
 o80_dummy
 ```
 
-To start a server over the real robot (on cent-os control desktop, **assuming you follow the procedure provided in the pam_interface [documentation](https://intelligent-soft-robots.github.io/code_documentation/pam_interface/docs/html/index.html)**)
+To start a server over the real robot (on cent-os control desktop, **assuming you follow the procedure provided in the [pam_interface](https://github.com/intelligent-soft-robots/pam_interface) documentation**)
 
 ```bash
 o80_real 

--- a/C5_visual_ball_tracking.md
+++ b/C5_visual_ball_tracking.md
@@ -11,7 +11,7 @@ The robot lab is equiped with four rgb cameras, which can be used to track the (
 For the server, the software used for this is [tennicam](https://github.com/intelligent-soft-robots/tennicam) which has been developped internally by Sebastian Gomez-Gonzalez.
 The desktop "rodau" is installed with the server software, and the cameras are plugged to it, ready to be used.
 For the client, the software used is [tennicam_client](https://github.com/intelligent-soft-robots/tennicam_client),
-which implements an [o80](http://people.tuebingen.mpg.de/mpi-is-software/o80/docs/o80/index.html) standalone. The client is install along the pam software, as described [here](https://intelligent-soft-robots.github.io/pam_documentation/A1_overview_and_installation.html). 
+which implements an {doc}`o80 <o80:index>` standalone. The client is install along the pam software, as described [here](https://intelligent-soft-robots.github.io/pam_documentation/A1_overview_and_installation.html). 
 
 ### How-to
 
@@ -47,7 +47,7 @@ in another terminal:
 tennicam_client_print
 ```
 
-In your python code, you may then use an [o80](http://people.tuebingen.mpg.de/mpi-is-software/o80/docs/o80/index.html) frontend
+In your python code, you may then use an {doc}`o80 <o80:index>` frontend
 to access ball informations.
 
 ```python

--- a/C5_visual_ball_tracking.md
+++ b/C5_visual_ball_tracking.md
@@ -11,7 +11,7 @@ The robot lab is equiped with four rgb cameras, which can be used to track the (
 For the server, the software used for this is [tennicam](https://github.com/intelligent-soft-robots/tennicam) which has been developped internally by Sebastian Gomez-Gonzalez.
 The desktop "rodau" is installed with the server software, and the cameras are plugged to it, ready to be used.
 For the client, the software used is [tennicam_client](https://github.com/intelligent-soft-robots/tennicam_client),
-which implements an {doc}`o80 <o80:index>` standalone. The client is install along the pam software, as described [here](https://intelligent-soft-robots.github.io/pam_documentation/A1_overview_and_installation.html). 
+which implements an {doc}`o80 <o80:index>` standalone. The client is install along the pam software, as described [here](A1_overview_and_installation). 
 
 ### How-to
 

--- a/E1_tools.md
+++ b/E1_tools.md
@@ -2,7 +2,7 @@
 
 This guide is here for those who would like to upgrade/extend PAM's software (as opposed to use it in their own code).
 
-For updating the code, the colcon workspace installation is required, as described [here](http://people.tuebingen.mpg.de/mpi-is-software/pam/docs/pam_documentation/doc/A1_overview_and_installation.html#via-colcon-workspace).
+For updating the code, the colcon workspace installation is required, as described {ref}`here <install_via_colcon>`.
 
 The workflow is based on these tools: github, treep, ament, colcon, pybind11 and gtest.
 

--- a/E3_packages_overview.md
+++ b/E3_packages_overview.md
@@ -11,7 +11,7 @@ Here a graph providing the dependencies between all the packages.
 
 ![graph dependencies](https://intelligent-soft-robots.github.io/images/dependencies_graph.png)
 
-Overview of all packages (bottom to top) : 
+Overview of all packages (bottom to top) :
 
 - [shared memory](https://github.com/machines-in-motion/shared_memory): package for (realtime) **interprocess sharing of data** via a shared memory.
 
@@ -27,26 +27,25 @@ Overview of all packages (bottom to top) :
 
 - [pam_interface](https://github.com/intelligent-soft-robots/pam_interface): **low level code / drivers for connecting to the PAM robot**. This packages also contains the code for starting a **dummy pam robot** (i.e. a robot with the same API as the real robot, for debugging purposes).
 
-This package is host of the executables:
+  This package is host of the executables:
 
   - pam_server (python) : starts a server process for control of either the real or a dummy robot
-
   - pam_check (python): activates all dof of the robot one by one. Can also be used as an example on how to send/read command to pam_server
 
-It is also the host of this configuration file (installed in /opt/mpi-is):
+  It is also the host of this configuration file (installed in /opt/mpi-is):
 
   - pam.json : for setting the minimum and maximum pressures to apply to the robot, as well as setting the server frequency
 
-- [o80_pam](https://github.com/intelligent-soft-robots/o80_pam): **o80 API for control over the PAM robot**. While pam_server only allows for direct commands, o80_pam allows for sending queues of commands to the robot. 
+- [o80_pam](https://github.com/intelligent-soft-robots/o80_pam): **o80 API for control over the PAM robot**. While pam_server only allows for direct commands, o80_pam allows for sending queues of commands to the robot.
 
-It also comes with the following python modules:
+  It also comes with the following python modules:
 
   - o80_pressures : the class **o80Pressures** is a convenience class to send pressures commands to the robot (and reading state of the robot) via o80
   - o80_robot_mirroring : the class **o80RobotMirroring** is a convenience class to send desired position/velocity commands to the robot. Can be used only for the control of mujoco robots (see o80_mujoco package below)
   - o80_ball , o80_hit_point, o80_goal: the classes **o80Goal**, **o80Ball**, **o80HitPoint** are convenience classes to set position of ball/goal/hit points to mujoco robots
   - joint_position_controller: the class **JointPositionController** implements a PID controller that will compute the control pressures to apply to the robot to reach a desired robot joint posture (in terms of radians for each dof).
 
-This package hosts these executables:
+  This package hosts these executables:
 
   - o80_dummy : starts a **control server** over a dummy pam robot
   - o80_real: starts a **control server** over the real robot
@@ -58,16 +57,16 @@ This package hosts these executables:
 - [pam_models](https://github.com/intelligent-soft-robots/pam_models): **artificial muscle models in c++** (currently only the hill model). Included configuration files (installed in /opt/mpi-is):
 
   - hill.json : all parameters of the model
-  
+
 - [context](https://github.com/intelligent-soft-robots/context): packages meant to host utility code useful to create environments. Currently, host the code for managing **pre-recorded (table tennis) ball trajectories** (in python, see ball_trajectories.py). The pre-recorded trajectories are installed in /opt/mpi-is/context
 
-- [pam_mujoco](https://github.com/intelligent-soft-robots/pam_mujoco) : code for managing **simulated PAM robot(s) in the context of table tennis**. This package hosts the code for **generating mujoco models of robots, table and balls**, and starting a corresponding **mujoco simulations**. All items (robot, ball, etc) may be controlled via an **o80 python API**. 
-The python packages hosts: 
+- [pam_mujoco](https://github.com/intelligent-soft-robots/pam_mujoco) : code for managing **simulated PAM robot(s) in the context of table tennis**. This package hosts the code for **generating mujoco models of robots, table and balls**, and starting a corresponding **mujoco simulations**. All items (robot, ball, etc) may be controlled via an **o80 python API**.
+The python packages hosts:
 
   - models.py : the generate_model function allows to create customized mujoco model
   - mujoco_handle.py : source code for the pam_mujoco handles
 
-This package also hosts the executables:
+  This package also hosts the executables:
 
   - pam_mujoco : starts a mujoco simulated robot(s)
   - pam_mujoco_no_xterms : starts a mujoco simulated robot(s)
@@ -75,5 +74,5 @@ This package also hosts the executables:
   - pam_mujoco_stop_all : killing all instances of pam_mujoco
   - pam_mujoco_visualization: visualization of pam_mujoco (useful if the latest has not been started with graphics)
 
- 
+
 - [pam_documentation](https://github.com/intelligent-soft-robots/pam_documentation): host of the documentation you are currently reading.

--- a/E3_packages_overview.md
+++ b/E3_packages_overview.md
@@ -21,11 +21,11 @@ Overview of all packages (bottom to top) :
 
 - [synchronizer](https://github.com/intelligent-soft-robots/synchronizer): tool for **synchronizing processes**, with interoperability between c++ and python. E.g. a python process may be used to set the frequency of a c++ process.
 
-- [o80](https://intelligent-soft-robots.github.io/code_documentation/o80/docs/html/index.html): **wrapper over time series and synchronizer**. The time series API is enriched with methods for **managing queues of commands** via python.
+- {doc}`o80 <o80:index>`: **wrapper over time series and synchronizer**. The time series API is enriched with methods for **managing queues of commands** via python.
 
-- [o80_example](https://intelligent-soft-robots.github.io/code_documentation/o80_example/docs/html/index.html) : canonical example / tutorial of o80
+- {doc}`o80_example <o80_example:index>`: canonical example / tutorial of o80
 
-- [pam_interface](https://intelligent-soft-robots.github.io/code_documentation/pam_interface/docs/html/index.html): **low level code / drivers for connecting to the PAM robot**. See the [documentation](https://intelligent-soft-robots.github.io/code_documentation/pam_interface/docs/html/index.html) of this package to see basic usage of this robot. This packages also contains the code for starting a **dummy pam robot** (i.e. a robot with the same API as the real robot, for debugging purposes). 
+- [pam_interface](https://github.com/intelligent-soft-robots/pam_interface): **low level code / drivers for connecting to the PAM robot**. This packages also contains the code for starting a **dummy pam robot** (i.e. a robot with the same API as the real robot, for debugging purposes).
 
 This package is host of the executables:
 

--- a/E3_packages_overview.md
+++ b/E3_packages_overview.md
@@ -7,10 +7,6 @@ or at the [github "Machines in Motion Laboratory" organization](https://github.c
 
 If you installed the software via treep/colcon or via the source tar ball (as described [here](A1_overview_and_installation)), these package are also present on your machine.
 
-Here a graph providing the dependencies between all the packages.
-
-![graph dependencies](https://intelligent-soft-robots.github.io/images/dependencies_graph.png)
-
 Overview of all packages (bottom to top) :
 
 - [shared memory](https://github.com/machines-in-motion/shared_memory): package for (realtime) **interprocess sharing of data** via a shared memory.

--- a/conf.py
+++ b/conf.py
@@ -183,4 +183,10 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
+intersphinx_mapping = {
+    "o80": ("http://people.tuebingen.mpg.de/mpi-is-software/o80/docs/o80/", None),
+    "o80_example": (
+        "http://people.tuebingen.mpg.de/mpi-is-software/o80/docs/o80_example",
+        None,
+    ),
+}


### PR DESCRIPTION
## Description

- Fix some dead links to documentation of o80 and use intersphinx for all references to it for better maintainability (URL is stored only in one place).  Note: This uses some syntax specific to the MyST Markdown parser used by Sphinx, which allows the use of restructuredText roles in Markdown (`{doc}'o80 <o80:index>'`).
- Fix some internal references.
- Remove links to pam_interface documentation which doesn't exist anymore (replaced them with links to the repository).
- Removed broken dependency graph image.
- Fixed indentation issue in the package list.

## How I Tested

Build locally.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
