### PR TITLE
Unifying headings and spelling, rephrasing and adding of markdown elements

### DIFF
--- a/A1_overview_and_installation.md
+++ b/A1_overview_and_installation.md
@@ -4,11 +4,11 @@
 
 ![pam robot](https://ei.is.tuebingen.mpg.de/uploads/publication/image/18667/2PAMcompressed.jpg)
 
-PAM robot (pneumatic artificial muscle robot) is a four degrees of freedom robot. Most of the days, we have it learn how to play tennis table. But it could be used for other purposes, e.g. exploring the control of artificial muscles.
+PAM robot (Pneumatic Artificial Muscle robot) is a four degrees of freedom robot. Most of the days, we have it learning how to play tennis table. But it could be used for other purposes, e.g. exploring the control of artificial muscles.
 
 It is controlled via the value of pressures of its 8 artificial muscles. Each joint is connected to 2 artificial muscles, called agonist and antagonist. If the pressure of the agonist is higher than the pressure of the antagonist (i.e. the agonist is more contracted than the antagonist), the joint moves left. A control command consists of setting the pressure(s) of one (or more) muscle(s).
 
-We developed some software allowing for the control of the robot (or a [mujoco](http://www.mujoco.org/) simulated version of it). The software allows to send commands related to the desired pressures to the robot, as well as accessing the current and past states of the robot. The software is written in C++ and has python wrappers (and has been tested only on ubuntu).
+We developed some software allowing for the control of the robot (or a [MuJoCo](http://www.mujoco.org/) simulated version of it). The software allows to send commands related to the desired pressures to the robot, as well as accessing the current and past states of the robot. The software is written in C++ and has Python wrappers (and has been tested only on Ubuntu).
 
 Once the software installed, the typical workflow starts with calling in a terminal:
 
@@ -29,7 +29,7 @@ pam_mujoco mujoco_id
 
 The command above spawns a "backend" process which connects to the robot. This process reads continuously (i.e. at a frequency of 200Hz or more) the state of the robot and writes it in a shared memory. Also, it reads the shared memory for commands to apply to the robot. 
 
-User may then use a python (or a c++) API for interacting with the shared memory, i.e. reading the state of the robot (written by the backend) or writing commands to it (which will then be read by the backend and applied to the robot).
+User may then use a Python (or a C++) API for interacting with the shared memory, i.e. reading the state of the robot (written by the backend) or writing commands to it (which will then be read by the backend and applied to the robot).
 
 There are quite a few types of commands that can be written in the shared memory. The system is based on o80, and it is advised to read o80's {doc}`documentation <o80:index>` before going further.
 
@@ -39,33 +39,45 @@ Installing the software will results in:
 
 - having some executables installed on your system (e.g. 'o80_pam' or 'pam_mujoco' already mentioned above)
  
-- having some python packages installed
+- having some Python packages installed
  
-- useful for advanced users: some c++ libraries installed
+- useful for advanced users: some C++ libraries installed
 
-The executables will be used to start the backend connecting to the robot, while the python packages can be used for developers to create control scripts that send commands to the backend (via the shared memory) and/or read states of the robot (also via the shared memory).
+The executables will be used to start the backend connecting to the robot, while the Python packages can be used for developers to create control scripts that send commands to the backend (via the shared memory) and/or read states of the robot (also via the shared memory).
 
-Note that you need a valid [mujoco key](https://www.roboti.us/license.html) to use the mujoco simulated robot.  
+Note that you need a valid [MuJoCo key](https://www.roboti.us/license.html) to use the MuJoCo simulated robot.  
+
+### Procedure
+
+> 1. Download binaries or source files from MPI-IS server
+> 2. Extract files and subsequently run scripts as explained in the following for installing the necessary dependencies
+> 3. Download and move MuJoCo key to specified location
+> 4. (Optional:) Setup colcon workspace
+> 5. (Optional:) Setup SSH authentification for GitHub
+> 6. Clone project repository from GitHub
+> 7. Compile project with ```colcon```
+> 8. Source terminal with given setup script
+> 9. Run test import commands in terminal
 
 ### From tar archives
 
 The below will:
 
-- install mujoco in /usr/local/
+- install the [MuJoCo physics engine](https://mujoco.org/) in /usr/local/
  
 - create configuration files in /opt/mpi-is
  
-- install (c++) libraries and python packages
+- install C++ libraries and Python packages
 
-#### binaries
+#### Binaries
 
-pam software's binaries are available only for ubuntu18.04/python3.6 and ubuntu20.04/python3.8.
+PAM software's binaries are available only for ubuntu18.04/python3.6 and ubuntu20.04/python3.8.
 
 To install, first select a version by visiting : [http://people.tuebingen.mpg.de/mpi-is-software/pam/latest/](http://people.tuebingen.mpg.de/mpi-is-software/pam/latest/) or [http://people.tuebingen.mpg.de/mpi-is-software/pam/older/](http://people.tuebingen.mpg.de/mpi-is-software/pam/older/). Then, for example (update with your selected version):
 
 ```bash
 wget http://people.tuebingen.mpg.de/mpi-is-software/pam/latest/pam_ubuntu20.04_py3.8_1.0.tar.gz
-tar -zxvf ./pam_ubuntu20.04_py3.8_1.0.tar.gz
+tar -zxvf ./pam_ubuntu20.04_py3.8_1.<your-version-number>.tar.gz
 sudo ./apt-dependencies
 sudo ./pip3-dependencies
 sudo ./create_config_dirs
@@ -75,7 +87,7 @@ sudo make install # note: 'make install' is directly called, no previous call to
 sudo ldconfig
 ```
 
-#### sources
+#### Sources
 
 ```bash
 wget http://people.tuebingen.mpg.de/mpi-is-software/pam/latest/pam_source.tar.gz
@@ -90,32 +102,36 @@ sudo make install
 sudo ldconfig
 ```
 
-#### mujoco key
+#### MuJoCo key
 
-Copy your mujoco key (mjkey.txt) in /opt/mujoco.
+Copy your MuJoCo key (mjkey.txt) in /opt/mujoco.
+
+```bash
+sudo cp ~/Downloads/mjkey.txt /opt/mujoco   #you may downloaded your key-file in another location
+```
 
 
 (install_via_colcon)=
 
 ### Via colcon workspace
 
-This is the recommanded way for developpers of the PAM software (as opposed to the users of it).
+This is the recommended way for developers of the PAM software (as opposed to the users of it).
 
 [Colcon](https://colcon.readthedocs.io/en/released/) is the built system of [ROS2](https://docs.ros.org/en/foxy/index.html).
 The instructions below will result in the setup of a colcon workspace. Possibly, if you would like to use o80 in a ROS2 project, you may copy the cloned packages to an existing workspace.
 
-#### Adding your ssh key to github
+#### Adding your SSH key to github
 
 See: [github documentation](https://help.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh).
 
-All the following instructions assume your ssh key has been activated, i.e.:
+All the following instructions assume your SSH key has been activated, i.e.:
 
 ```bash
 # replace id_rsa by your key file name
 ssh-add ~/.ssh/id_rsa
 ```
 
-- You must first register your ssh-key to github. See instructions [here](https://docs.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
+- You must first register your SSH key to Github. See instructions [here](https://docs.github.com/en/github/authenticating-to-github/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
 
 - treep is likely to be already installed on your machine. If not:
 ```bash
@@ -138,10 +154,6 @@ sudo ./install_mujoco
 sudo ./pip3-dependencies
 ```
 
-#### mujoco key
-
-Copy your mujoco key (mjkey.txt) in /opt/mujoco.
-
 #### Cloning the repositories
 
 Creating a folder and cloning the treep configuration:
@@ -163,7 +175,7 @@ treep --clone PAM_MUJOCO
 ```bash
 cd /path/to/Software
 cd workspace
-colcon build --cmake-args ' -DCMAKE_BUILD_TYPE=Release '
+colcon build --cmake-args ' -DCMAKE_BUILD_TYPE=Release ' # you may need to call this command as root
 ```
 
 This will result in a "install" folder containing the compiled binaries
@@ -175,9 +187,9 @@ In each new terminal, the workspace needs to be sourced:
 ```bash
 source /path/to/Software/install/setup.bash
 ```
-
+```{note}
 Possibly, you may want to add the line above to the ~/.bashrc file (so that each new terminal source the workspace automatically).
-
+```
 
 ###  Checking things are ok
 

--- a/B1_tutorial0.md
+++ b/B1_tutorial0.md
@@ -4,13 +4,19 @@ Code for demos and tutorials can be found in the pam_demos [repository](https://
 
 The typical process to run a demo or a tutorial is:
 
-In a terminal, start pam_mujoco, with the correct mujoco_id:
+1. Open the terminal (of your choice)
+2. Use the ```pam_mujoco```-command with the corresponding "mujoco_id"
+3. Run a Python-script with the desired (control) commands.
+
+## Starting a demonstration or tutorial
+
+First, a MuJoCo handle (in the following indicated by the mujoco_id) has to be specified. For each tutorial a tutorial-specific mujoco_id has been prepared and can be found in the corresponding Python-script. 
 
 ```bash
 pam_mujoco mujoco_id
 ```
 
-The "mujoco_id" to use depends on the demo, and is indicated in the source file of the demo, or in the readme. For example, for tutorial 1:
+For example, for Tutorial 1:
 
 ```bash
 pam_mujoco tutorials_1_to_3
@@ -31,11 +37,9 @@ python ./tutorial_1.py
 # python should be of version 3.x
 ```
 
-Note that you may run the demo several times without the need to restart pam_mujoco.
+## Stopping a demonstration or tutorial
 
-The mujoco simulation can be stopped.
-
-If you started with a x-terminal, you may simply close the terminal. Alternatively, you may call:
+The MuJoCo simulation can be stopped. For stopping the simulation, you may simple close the terminal from which you started the xterminal-application. Alternatively, you may call:
 
 ```bash
 pam_mujoco_stop tutorials_1_to_3
@@ -48,6 +52,10 @@ pam_mujoco_stop_all
 # will stop all running pam_mujoco
 ```
 
+## Further remarks
+
+* Note that you may run the demo several times without the need to restart pam_mujoco.
+* The "mujoco_id" depends on the demo and is indicated in the source file of the demo or in the README-file. Further information regarding the mujoco_id can be found here: [MuJoCo handles and contacts](C1_handle).
 
 
 

--- a/B2_tutorial1.md
+++ b/B2_tutorial1.md
@@ -1,6 +1,6 @@
 # Tutorial 1: Commands
 
-## Starting a Mujoco simulated robot
+## Starting a MuJoCo simulated robot
 
 In a terminal, call:
 ```bash
@@ -20,7 +20,7 @@ You may now run tutorial_1.py
 python3 ./tutorial_1.py
 ```
 
-Here some comments regarding the source code similar of the one of tutorial 1.
+Here some comments regarding the source code similar of the one of Tutorial 1.
 
 ```python
 
@@ -130,7 +130,7 @@ the code above has the robot starting to go toward the pressures 12000, but afte
 
 ## add_command overloads
 
-### controlling only selected muscle(s)
+### Controlling only selected muscle(s)
 
 All the commands applied so far targeted all muscles. It is possible to request the change of the pressure of only one muscle:
 
@@ -148,7 +148,7 @@ frontend.pulse()
 ```
 Note that the command above will have the muscles 0 and 1 changing pressure at the same time. Because these two commands target 2 different muscles, the second command does not overwrite the first one.
 
-### controlling a degree of freedom
+### Controlling a degree of freedom
 
 ```python
 dof=0
@@ -158,7 +158,7 @@ frontend.pulse()
 The command above will have the pressures of the agonist and antagonist muscles of the degree of freedom indexed 0 reach the values 20000 and 15000 (respectively) in 3 seconds. 
 
 
-### controlling all muscles
+### Controlling all muscles
 
 ```python
 agonists = [15000,16000,17000,18000]
@@ -168,7 +168,7 @@ frontend.pulse()
 ```
 This command will target all muscles, for example the target pressure values for the first degree of freedom will be (15000,18000).
 
-### speed commands
+### Speed commands
 
 All the commands so far have been *duration* command, i.e. the request to interpolate between the current desired pressure value to a target desired pressure value over a given duration. It is possible to also create speed command, i.e. requesting the desired pressures to achieve a target value at a certain velocity (in terms of unit of pressure per unit of time).
 
@@ -184,7 +184,7 @@ frontend.add_command(3,15000,o80.Speed.per_second(400),o80.Mode.OVERWRITE)
 frontend.add_command(4,20000,o80.Speed.per_second(300),o80.Mode.OVERWRITE)
 frontend.pulse()
 ```
-### direct commands
+### Direct commands
 
 It is possible to create commands that do not specify any duration or speed. Direct commands request the desired pressure to reach the target pressure as fast as possible. For example:
 
@@ -241,7 +241,7 @@ The code above requested to create an handle to the *pam_mujoco* process running
 "tutorials_1_3", and configuring it:
 
 - to run a pressure controlled robot with segment_id "robot"
-- to show mujoco graphics
+- to show MuJoCo graphics
 - to run realtime (and not accelerated_time)
 
 During the handle creation, the corresponding configuration is written in the shared memory, and

--- a/B3_tutorial2.md
+++ b/B3_tutorial2.md
@@ -1,18 +1,18 @@
-# Tutorial 2: reading robot data
+# Tutorial 2: Reading robot data
 
 ## Reading robot data
 
-Tutorial 2 is started similarly to tutorial 1.
+Tutorial 2 is started similarly to [Tutorial 1](B2_tutorial1).
 
-While in tutorial 1 the frontend was used to send command to the pressure controlled robot,
-in tutorial 2 the frontend is used to read the robot data.
+While in Tutorial 1 the frontend was used to send command to the pressure controlled robot,
+in Tutorial 2 the frontend is used to read the robot data.
 
 ```python
 handle = get_handle()
 frontend = handle.frontends["robot"]
 observation = frontend.latest()
 ```
-observation is an instance of Observation. It contains has the following method:
+"observation" is an instance of the Observation-class. It contains has the following method:
 
 ```python
 # at each backend iteration (i.e. control iteration of o80_mujoco), an observation is generated.                  

--- a/B4_tutorial3.md
+++ b/B4_tutorial3.md
@@ -1,14 +1,14 @@
-# Tutorial 3: iteration commands
+# Tutorial 3: Iteration commands
 
 ## Introduction
 
-In tutorial 1, we covered duration, speed and direct commands. This tutorial introduce the iteration command.
+In [Tutorial 1](B2_tutorial1), we covered duration, speed and direct commands. This tutorial introduce the iteration command.
 
 "Iteration" refers to the backend, i.e. the control iteration of the robot. At each control iteration, the backend reads the commands queue, compute the desired pressure to apply to the robot, applies it to the robot, read the current state of the robot from sensors and write a corresponding Observation in the shared memory.
 
-Iteration commands allows to specify using a python frontend the value of the desired pressure for upcoming iteration numbers.
+Iteration commands allows to specify using a Python frontend the value of the desired pressure for upcoming iteration numbers.
 
-Tutorial 3 is started similarly to tutorials 1 and 2.
+Tutorial 3 is started similarly to Tutorials 1 and 2.
 
 ## Getting the current iteration number
 
@@ -18,9 +18,9 @@ frontend = handle.frontends["robot"]
 iteration = frontend.latest().get_iteration()
 ```
 
-## waiting for an iteration
+## Waiting for an iteration
 
-In tutorial 2, the *read* method of the frontend was used to access from the shared memory an observation corresponding to a past iteration.
+In [Tutorial 2](B3_tutorial2), the *read* method of the frontend was used to access from the shared memory an observation corresponding to a past iteration.
 The same method can be used to wait for an upcoming iteration:
 
 ```python
@@ -31,7 +31,7 @@ observation = frontend.read(future_iteration)
 reached_iteration = observation.get_iteration() # will be equal to future_iteration
 ```
 
-## example
+### Example
 
 ```python
 frontend = o80_pam.FrontEnd("o80_pam_robot")
@@ -75,7 +75,7 @@ print("reached iteration: {}".format(observation.get_iteration()))
 
 In this example, the desired pressure values that should be applied at exact backend iteration numbers are specified from the frontend.
 
-## synchronizing the frontend and the backend
+## Synchronizing the frontend and the backend
 
 This example of usage is a bit evolved:
 
@@ -102,21 +102,21 @@ time_end = time.time()
 print("frequency: {} Hz".format(500.0/(time_end-time_start)))
 ```
  
-During the time the backend applies a command, the frontend computes the control value that should be applied at the next frontend control loop. This has the frontend running at a frequency enforced by the backend. This is important because the frontend is not realtime safe (because python is not realtime), while the backend may be.
+During the time the backend applies a command, the frontend computes the control value that should be applied at the next frontend control loop. This has the frontend running at a frequency enforced by the backend. This is important because the frontend is not real-time safe (because python is not realtime), while the backend may be.
 
 
-## relative iteration
+## Relative iteration
 
 So far, all iteration number were *absolute*, i.e. iteration numbers as counted since the start of the backend.
 
 It is possible to use relative iteration number, i.e. the iteration number as counted from a later time.
 
-The o80 class Iteration takes two extra boolean arguments:
+The o80-class Iteration takes two extra boolean arguments:
 
 - relative: if True (False is the default), it corresponds to a relative iteration number
 - reset: if True (False is the default), a command using this instance of Iteration reset the iteration counter.
 
-Example:
+### Example:
 
 ```python
 # this corresponds to 1000 iterations counting                                                                                                                                                                                                                                            

--- a/B5_tutorial4.md
+++ b/B5_tutorial4.md
@@ -1,12 +1,12 @@
-# Tutorial 4: join control, table, balls, etc
+# Tutorial 4: Joint control, table, balls, etc.
 
 ## Tutorial's demo
 
-This demo is started similarly to tutorials 1 to 3, with the exception that pam_mujoco should
+This demo is started similarly to the Tutorials 1 to 3, with the exception that pam_mujoco should
 be start with mujoco_id *tutorial_4*
 
 ```bash
-pan_mujoco tutorial_4
+pam_mujoco tutorial_4
 ```
 
 then
@@ -15,9 +15,9 @@ then
 python ./tutorial_4.py
 ```
 
-## Handle and mujoco xml files
+## Handle and MuJoCo XML files
 
-The source code of tutorial 4 starts with the mujoco simulation configuration:
+The source code of Tutorial 4 starts with the MuJoCo simulation configuration:
 
 ```python
 robot = pam_mujoco.MujocoRobot("robot",
@@ -51,13 +51,9 @@ Once the (waiting) instance of *pam_mujoco* reads (from the shared memory) this 
 /tmp/tutorial_4/tutorial_4.xml
 ```
 
-The handle requests the configuration file to describe an environment with 1 robot, 2 balls, a hit point and to display a table, and indeed this is what pam_mujoco spawns.
+The handle requests the configuration file to describe an environment with 1 robot, 2 balls, a hit point and to display a table and indeed this is what pam_mujoco spawns.
 
-On top of this, the handle requests the robot to be joint controlled, and the balls and hit point to be also be controlled.
-
-
-
-
+On top of this, the handle requests the robot to be joint controlled as well as the balls and the hit point to be also be controlled.
 
 ### Model factory
 
@@ -76,7 +72,7 @@ items = pam_mujoco.model_factory(model_name, # arbitrary string
                                  muscles=True)
 ```
 
-Call to model_factory results in the generation of an Mujoco xml model file. The absolute path to this file is accessible:
+Call to model_factory results in the generation of an MuJoCo-XML-model-file. The absolute path to this file is accessible:
 
 ```python
 path = items["path"]
@@ -123,7 +119,7 @@ pam_mujoco.request_stop(mujoco_id)
 
 ### Interacting with a ball
 
-The script above started a simulation containing 3 simulated balls. These balls are subject to the (simulated) gravity, and will just fall forever. Not very exciting.
+The script above started a simulation containing 3 simulated balls. These balls are subject to the (simulated) gravity and will just fall forever. Not very exciting.
 
 o80 can be used to interact the simulated balls, e.g. forcing the position/velocity of the balls and/or getting information about the balls.
 
@@ -156,7 +152,7 @@ pam_mujoco.add_o80_ball_control("ball0",balls[0])
 pam_mujoco.execute(mujoco_id,items["path"])
 ```
 
-The method "add_o80_for_ball" reads "add an o80 backend to the Mujoco simulation". Consequently, the ball is no longer subject to gravity but gets fully controlled based on user commands: one interact with the first ball via o80 frontend instantiated in another script (or another process in the same script):
+The method "add_o80_for_ball" reads "add an o80 backend to the MuJoCo simulation". Consequently, the ball is no longer subject to gravity but gets fully controlled based on user commands: one interact with the first ball via o80 frontend instantiated in another script (or another process in the same script):
 
 ```python
 import pam_mujoco
@@ -190,7 +186,7 @@ pam_mujoco.add_o80_ball_control("ball0",
 
 This ball may enter in contact with the table and/or the racket of the robot(s). It is possible to retrieve related information.
 
-First, in the same way that a o80 backend was added to the mujoco simulation via the method "add_o80_ball_control", contact controllers have to be added to the mujoco simulation:
+First, in the same way that a o80 backend was added to the MuJoCo simulation via the method "add_o80_ball_control". Contact controllers have to be added to the MuJoCo simulation:
 
 ```python
 ball = items["ball"][0]
@@ -210,7 +206,7 @@ import pam_mujoco
 # note the contact id is the same as above
 contact = pam_mujoco.get_contact("contact_table_ball") 
 ```
-contact is the instance of a class providing the public attributes:
+"contact" is the instance of a class providing the public attributes:
 
 ```python
 # True if a contact ever occurred
@@ -233,7 +229,7 @@ pam_mujoco.reset_contact("contact_table_ball")
 
 ### Playing a recorded ball trajectory
 
-We recorded trajectories of real ball being launched and bouncing on a table tennis table. A python API allows to query these trajectories.
+We recorded trajectories of real ball being launched and bouncing on a table tennis table. A Python-API allows to query these trajectories.
 For example:
 
 ```python
@@ -286,11 +282,11 @@ frontend_ball.pulse()
 ```
 
 
-### Hybrid: controlling a ball until contact
+### Hybrid: Controlling a ball until contact
 
-It is possible to use an o80 frontend to control a ball, but letting Mujoco's physic engine taking over once a contact occured.
+It is possible to use an o80 frontend to control a ball, but letting MuJoCo's physic engine taking over once a contact occured.
 
-Above, the function "add_o80_ball_control" was introduced. It was used to set an o80 backend for ball control in the mujoco simulation.
+Above, the function "add_o80_ball_control" was introduced. It was used to set an o80 backend for ball control in the MuJoCo simulation.
 
 An alternative method is: "add_o80_ball_control_until_contact".
 
@@ -310,9 +306,9 @@ Once the contact is reset:
 pam_mujoco.reset_contact("table")
 ```
 
-## Goal, HitPoint
+## Goal, hit point
 
-Goal and HitPoint are visual markers. They can also be added to the mujoco's model, for example:
+Goal and HitPoint are visual markers. They can also be added to the MuJoCo's model, for example:
 
 ```python
 items = pam_mujoco.model_factory(model_name,
@@ -345,7 +341,7 @@ goal.pulse()
  
 ## Joint Control
 
-Mujoco simulated pam robot can be joint controlled (i.e. setting for each degree of freedom a desired joint angle and a desired angular velocity). 
+MuJoCo simulated PAM-robot can be joint controlled (i.e. setting for each degree of freedom a desired joint angle and a desired angular velocity). 
 
 For this, it is required to add a joint controller, for example:
 

--- a/B6_tutorial5.md
+++ b/B6_tutorial5.md
@@ -1,4 +1,4 @@
-# Tutorial 5: saving data to files
+# Tutorial 5: Saving data to files
 
 Once a robot backend is started, for example by calling in a terminal:
 
@@ -73,9 +73,11 @@ print("... done")
 
 # latest will be the same as path
 print("data was saved in: {}",fm.latest())
-``` 
-**warning** : the file manager returns path that are in the tmp folder, so the files will be deleted automatically by the OS at some point. Be careful to backup the important files
+```
 
+```{Warning} 
+The file manager returns path that are in the tmp folder, so the files will be deleted automatically by the OS at some point. Be careful to backup the important files
+```
 
 ## Reading the data
 

--- a/B7_tutorial6.md
+++ b/B7_tutorial6.md
@@ -1,4 +1,4 @@
-# Tutorial 6: bursting mode
+# Tutorial 6: Bursting mode
 
 ## Introduction
 
@@ -33,7 +33,7 @@ you may see that a very low frequency is shown, and the iteration number does no
 
 This is because in bursting mode, the robot control iterates only when being asked to do so by a frontend.
 
-For example, in a python terminal:
+For example, in a Python terminal:
 
 ```python
 import o80

--- a/C1_handle.md
+++ b/C1_handle.md
@@ -1,4 +1,4 @@
-# More info: Mujoco handle and contacts
+# More info: MuJoCo handles and contacts
 
 
 In the tutorials, handles are used to configure the mujoco simulation spawed by *pam_mujoco*. The handles are also used to interface with the simulated robots, balls and other items.

--- a/C2_real_robot.md
+++ b/C2_real_robot.md
@@ -1,8 +1,8 @@
 # More info: Using the real robot
 
-## method 1: PAM Interface
+## Method 1: PAM interface
 
-pam_interface provides a python interface to the Pneumatic Artificial Muscle (PAM) (pam) developed at the Intelligent Soft Robots Laboratory (Empirical Inference Department, Max Planck Institute for Intelligent Systems).
+pam_interface provides a Python interface to the Pneumatic Artificial Muscle (PAM) developed at the Intelligent Soft Robots Laboratory (Empirical Inference Department, Max Planck Institute for Intelligent Systems).
 
 ![PAM_ROBOT](https://ei.is.tuebingen.mpg.de/uploads/publication/image/18667/2PAMcompressed.jpg)
 
@@ -26,7 +26,7 @@ The angular position of the joint is provided relative to the posture of the joi
 
 ### Installation
 
-#### On ubuntu
+#### On Ubuntu
 
 pam_interface follows the [general guidelines of IRS](https://github.com/intelligent-soft-robots/intelligent-soft-robots.github.io/wiki), and is provided by the treep project PAM.
 
@@ -39,9 +39,9 @@ You may therefore simply use treep to clone PAM, and compile as usual.
 
 ### Usage
 
-#### starting the server
+#### Starting the server
 
-After compilation and sourcing of the workspace, the pam_server is available, and can be started:
+After compilation and sourcing of the workspace, the pam_server is available and can be started:
 
 ```bash
 pam_server
@@ -58,14 +58,14 @@ The above obviously assumes you are working from the robot control workstation.
 See somewhere below for the instructions on how to start the robot (beyond the server)
 
 
-#### printed data
+#### Printed data
 
-Once the server started, it will print in the terminal, for each of the 4 dofs:
+Once the server started, it will print in the terminal for each of the 4 DOFs:
 
 - the value of the encoder (if the reference has not been found), the angular position of the joint otherwise (in degree)
 - the value of the observed and desired pressure for the agonist and antagonist muscles.
 
-#### sending desired pressures and reading sensors
+#### Sending desired pressures and reading sensors
 
 In another terminal, you may start a script using the following API:
 
@@ -82,7 +82,9 @@ pam_interface.write_command(segment_id,agos,antagos)
 robot_state = pam_interface.read_robot_state(segment_id)
 ```
 
-**warning**: "write_command" does not proceed any security check. If you send desired pressures that are very different to the current desired pressures, violent motions are likely to occur.
+```{danger}
+"write_command" does not proceed any security check. If you send desired pressures that are very different to the current desired pressures, violent motions are likely to occur.
+```
 
 robot_state is an instance of [RobotState](https://github.com/intelligent-soft-robots/pam_interface/blob/master/include/pam_interface/state/robot.hpp).
 
@@ -90,29 +92,33 @@ See its documentation [here](to do: point to the right url)
 
 ### Starting the real robot
 
-Parts :
+#### Parts
 
 - the "electronic box", which is turned on via the power outlet
 - the pressure valve (against the wall). Horizontal means closed
 - the emergency stop button, which blocks the pressure
 - the control software server (pam_interface or o80_real)
 
-Warning :
+```{warning}
+What is to be avoided is to have the pressure applied to the robot when the electronic box is off or the electronic box is on but the FPGA has not been initialized (the FPGA is initialized by the control software server). 
 
-What is to be avoided is to have the pressure applied to the robot when the electronic box is off, or the electronic box is on but the fpga has not been initialized (the fpga is initialized by the control software server). The electronic box and the server ensure that the pressure applied to the robot is limited. If the robot is exposed to the pressure while the electronic box is off or the fpga has not been initialized, the maximal pressure will be applied to it and damage may occur.
--> applying the pressure is always the last thing to do <-
+The electronic box and the server ensure that the pressure applied to the robot is limited. If the robot is exposed to the pressure, while the electronic box is off or the FPGA has not been initialized, the maximal pressure will be applied to it and damage may occur.
 
-What to do when in doubt :
+**Applying the pressure is always the last thing to do**
+```
+```{important}
+**What to do when in doubt:**
 Press the emergency button.
+```
 
-Starting state:
+#### Starting state
 
 - power outlet off
 - emergency button pressed
 - pressure valve closed (horizontal)
 - 4th degree of freedom of the robot "aligned" (silver paint marking aligned with zero)
 
-Starting steps:
+#### Starting steps
 
  1. Start electronic box (switch power outlet on)
  2. Start o80_real and o80_console. o80_console should show * as angle values, as the reference for the encoder should not have been found yet. If o80_console shows angles, restart the desktop.
@@ -125,7 +131,7 @@ Starting steps:
 
 (the 4th degree of freedome has some encoder issue, which explains this convulated starting process).
 
-Stopping steps:
+#### Stopping steps
 
 1. Stop server (software has pressure decrease on exit)
 2. Press emergency button
@@ -155,7 +161,7 @@ This documentation assumes you are familiar with both *pam_interface* and *o80*.
 
 ### Installation
 
-Follow the [general guidelines](https://github.com/intelligent-soft-robots/intelligent-soft-robots.github.io/wiki), using either the treep project "PAM" or the treep project "PAM_MUJOCO" (if you'd like to use o80_real over a PAM robot simulated by Mujoco).
+Follow the [general guidelines](https://github.com/intelligent-soft-robots/intelligent-soft-robots.github.io/wiki), using either the treep project "PAM" or the treep project "PAM_MUJOCO" (if you'd like to use o80_real over a PAM robot simulated by MuJoCo).
 
 If using mujoco, you also need to copy a mujoco licence key (mjkey.txt) in the folder /opt/mujoco/ (create the folder is necessary).
 
@@ -177,7 +183,7 @@ o80_real
 
 #### Checking all is working
 
-Once the o80 server started, you may check all is working fine by running in another terminal :
+Once the o80 server started, you may check all is working fine by running in another terminal:
 
 ```bash
 o80_check
@@ -193,7 +199,7 @@ o80_swing_demo
 
 #### Python user code
 
-See [tutorials 1 to 3](B2_tutorial1) for examples of a pressure controlled robot.
+See [Tutorials 1 to 3](B2_tutorial1) for examples of a pressure controlled robot.
 The difference with the tutorials, which show interfacing with a mujoco simulated robot, is that no handle is required to access the frontend. Instead, the frontend can be accessed directly:
 
 ```python

--- a/C3_executables.md
+++ b/C3_executables.md
@@ -1,4 +1,4 @@
-# More info: list of executables
+# More info: List of executables
 
 Once the [installation](A1_overview_and_installation) procedure completed, various executables are installed.
 
@@ -70,7 +70,7 @@ You may note that the process ids of the spawned processes are printed in the ma
 
 ## pam_mujoco_no_xterms
 
-Similar to *pam_mujoco* (right above) with the difference that the mujoco simulation are not hosted by new terminals, but in the background of the current terminal.
+Similar to *pam_mujoco* (right above) with the difference that the MuJoCo simulation are not hosted by new terminals, but in the background of the current terminal.
 
 ## pam_mujoco_visualization
 

--- a/C4_mirroring.md
+++ b/C4_mirroring.md
@@ -1,7 +1,7 @@
-# More info: mirroring real robot
+# More info: Mirroring real robot
 
 
-To get a mujoco simulated to mirror the real robot, first, start the real robot:
+To get a MuJoCo simulation to mirror the real robot, first, start the real robot:
 
 ```bash
 o80_real

--- a/C5_visual_ball_tracking.md
+++ b/C5_visual_ball_tracking.md
@@ -1,13 +1,14 @@
-# More info: visual ball tracking
+# More info: Visual ball tracking
 
-| page useful only  to the users in the Max Planck Institute for Intelligent Systems having access to the robot lab | --- |
+```{note}
+Page is only useful to persons having access to the robot lab in the Max Planck Institute for Intelligent Systems
+```
 
+## Operators
 
-## Users
+### Description
 
-### What it is
-
-The robot lab is equiped with four rgb cameras, which can be used to track the (3d) position of a table tennis ball.
+The robot lab is equiped with four RGB cameras, which can be used to track the (3D) position of a table tennis ball.
 For the server, the software used for this is [tennicam](https://github.com/intelligent-soft-robots/tennicam) which has been developped internally by Sebastian Gomez-Gonzalez.
 The desktop "rodau" is installed with the server software, and the cameras are plugged to it, ready to be used.
 For the client, the software used is [tennicam_client](https://github.com/intelligent-soft-robots/tennicam_client),
@@ -15,14 +16,14 @@ which implements an {doc}`o80 <o80:index>` standalone. The client is install alo
 
 ### How-to
 
-#### How to start the server
+#### How to start the server?
 
 - Turn on the "bright" light above the table tennis. 
 - Login to rodau using the ball_tracking user. The password is written on the desktop.
 - Open a terminal.
 - Call ```tennicam_start```. Two terminals should open. If they do not show any error message, the tracking is active.
 
-#### How to fix the server
+#### How to fix the server?
 
 If you experience any issue, you can try to run in a terminal:
 
@@ -31,7 +32,7 @@ If you experience any issue, you can try to run in a terminal:
 - tennicam_capture_indep: check if the desktop can use the drivers to capture pictures from the cameras
 - tennicam_capture: check if the desktop can use the drivers of the cameras to capture synchronized pictures
 
-#### How to start the client
+#### How to start the client?
 
 The client can be started on any Ubuntu desktop installed with the pam software.
 In a first terminal (you may use the default parameters):
@@ -72,7 +73,7 @@ print(ball.to_string())
 For an example, see the source code of ```tennicam_client_print``` [here](https://github.com/intelligent-soft-robots/tennicam_client/blob/master/bin/tennicam_client_print).
 
 
-#### How to display the tracked ball in mujoco
+#### How to display the tracked ball in MuJoCo?
 
 In a terminal:
 
@@ -87,10 +88,10 @@ and in another terminal:
 tennicam_client_display
 ```
 
-A mujoco simulation will start, displaying the ball.
+A MuJoCo simulation will start, displaying the ball.
 To stop the mujoco simulation, type in any terminal ```pam_mujoco_stop tennicam_client_display```.
 
-#### How to fix the transform of the ball
+#### How to fix the transform of the ball?
 
 The ball is detected in a given frame, and then its position goes through a transformation (translation and rotation).
 The transformation applied is specified in the configuration file ```/opt/mpi-is/tennicam_client/config/config.toml```
@@ -124,7 +125,7 @@ may see the result in the mujoco simulation poped up by ```tennicam_client_displ
 The dialog allows you to save the transform in the configuration file (i.e. to overwrite ```/opt/mpi-is/tennicam_client/config/config.toml```).
 This ensure the next time ```tennicam_client``` is started (without ```active_transform``` set to ```True```), the desired transform is applied. 
 
-#### How to log ball information
+#### How to log ball information?
 
 After starting ```tennicam_client```, start in another terminal:
 

--- a/C6_saving_ball_and_racket_contacts.md
+++ b/C6_saving_ball_and_racket_contacts.md
@@ -1,4 +1,4 @@
-# More info: saving ball trajectories
+# More info: Saving ball trajectories
 
 It is possible to save in files both the position and orientation as observed 
 by [tennicam_client](C5_visual_ball_tracking) and the state of the real robot
@@ -6,7 +6,7 @@ as observed by [o80_real](C2_real_robot). These files can be then replayed in a 
 simulation. This simulation will replay both the ball as observed (red ball) and as subject to 
 our [custom contact model](B5_tutorial4) (green ball). This is useful to assess the quality of the contact model.
 
-## How to
+## How-to
 
 ### Log files
 
@@ -37,7 +37,7 @@ and in a second terminal:
 o80_robot_ball_replay
 ```
 
-### Parsing files in python
+### Parsing files in Python
 
 The package o80_pam provides a parser for the saved files:
 

--- a/C7_ball_launcher.md
+++ b/C7_ball_launcher.md
@@ -1,8 +1,8 @@
-# More info: ball launcher
+# More info: Ball launcher
 
 The robot laboratory has a ball launcher that can be activated programmatically.
 
-## How to
+## How-to
 
 ### Start the ball launcher
 
@@ -68,7 +68,7 @@ All arguments are floats between 0 and 1 (except of ip which is string and port 
 
 ## Installation of the server
 
-On the raspberry pi of the ball launcher, install:
+On the Raspberry Pi of the ball launcher, install:
 
 - pip3 install: pyparsing==2.0.2, colcon-common-extensions, empy, catkin-pkg, sphinx, breathe, xinabox-OC05, xinabox-OC03
 - apt: protobuf-compiler, libprotobuf-dev, libzmq3-dev

--- a/E1_tools.md
+++ b/E1_tools.md
@@ -1,28 +1,28 @@
-# Developer's guide 1: tools
+# Developer's guide 1: Tools
 
 This guide is here for those who would like to upgrade/extend PAM's software (as opposed to use it in their own code).
 
 For updating the code, the colcon workspace installation is required, as described {ref}`here <install_via_colcon>`.
 
-The workflow is based on these tools: github, treep, ament, colcon, pybind11 and gtest.
+The workflow is based on these tools: GitHub, treep, ament, colcon, pybind11 and gtest.
 
-## Github
+## GitHub
 
 The source repositories are hosted in the "Intelligent Soft Robots" [domain](https://github.com/intelligent-soft-robots) of github.
-As treep (see below) uses ssh, you need to register your ssh key to github (see [here](https://docs.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account))
+As treep (see below) uses SSH, you need to register your SSH key to GitHub (see [here](https://docs.github.com/en/github/authenticating-to-github/adding-a-new-ssh-key-to-your-github-account))
 
 ## Treep
 
-To get the software compiled and running, several git repositories must be cloned.
+To get the software compiled and running, several Git repositories must be cloned.
 As it would be annoying to clone them one by one, we use the project manager [treep](https://pypi.org/project/treep/), which allows to clone several repositories at once.
 
-### installation
+### Installation
 
 ```bash
 pip install treep
 ```
 
-### configuration repository
+### Configuration repository
 
 treep needs a configuration folder. We use [treep_isr](https://github.com/intelligent-soft-robots/treep_isr.git):
 
@@ -32,7 +32,7 @@ cd Software
 git clone https://github.com/intelligent-soft-robots/treep_isr.git
 ```
 
-In the folder treep_isr, you will find the file *repositories.yaml* which provides repositories names, url and default branch (see also configuration.yaml). Once treep_isr has been cloned, you may see for example the list of repositories:
+In the folder treep_isr, you will find the file *repositories.yaml* which provides repositories names, URL and default branch (see also configuration.yaml). Once treep_isr has been cloned, you may see for example the list of repositories:
 
 ```bash
 treep # treep without argument prints some help
@@ -52,7 +52,7 @@ To see information about a specific projects:
 treep --project PAM_MUJOCO
 ```
 
-### cloning
+### Cloning
 
 You can use treep to clone a project (i.e. cloning all the repositories of the project):
 
@@ -60,15 +60,15 @@ You can use treep to clone a project (i.e. cloning all the repositories of the p
 treep --clone PAM_MUJOCO
 ```
 
-### status
+### Status
 
-The status argument is very useful to see the (git) status of each cloned repos (i.e. if they are behind origin, beyond origin, have modified files, etc)
+The status argument is very useful to see the (git) status of each cloned repos (i.e. if they are behind origin, beyond origin, have modified files, etc.)
 
 ```bash
 treep --status
 ```
 
-### pull 
+### Pull 
 
 You can use treep to update all the repositories
 
@@ -77,7 +77,7 @@ treep --pull
 ```
 
 
-### calling from anywhere
+### Calling from anywhere
 
 Note that you do not need to be in the Software folder to call treep, you may call treep for any of its subfolder, e.g.
 
@@ -94,19 +94,19 @@ An ament package contains typically:
 
 - C++ code, in the include/package_name and the source folders
 
-- python wrappers over this C++ code in the srcpy folder
+- Python wrappers over this C++ code in the srcpy folder
 
-- native python code in the python folder
+- Native python code in the python folder
 
-- unit tests in the tests folder
+- Unit tests in the tests folder
 
-- configuration files
+- Configuration files
 
-- a demos folder, containing source code providing example of usage of the code provided by the package
+- A demos folder containing source code providing example of usage of the code provided by the package
 
-- a package.xml file listing dependencies
+- A package.xml file listing dependencies
 
-- a CMakeLists.txt file containing the CMake commands required for compilation.
+- A CMakeLists.txt file containing the CMake commands required for compilation.
 
 The [context](https://github.com/intelligent-soft-robots/context) and [pam_interface](https://github.com/intelligent-soft-robots/pam_interface) repositories provide examples of a packages containing most of the above.
 
@@ -153,13 +153,13 @@ This will compile only the selected package and its required dependencies.
 
 ## Pybind11
 
-Most of the code is in C++, but made available as python package.
+Most of the code is in C++, but made available as Python package.
 
-We use [pybind11](https://pybind11.readthedocs.io/en/master/?badge=master) for creating wrappers over c++ code.
+We use [pybind11](https://pybind11.readthedocs.io/en/master/?badge=master) for creating wrappers over C++ code.
 
-By convention, the c++ binding code should be in the srcpy folder of the package, and in the file wrappers.cpp.
+By convention, the C++ binding code should be in the srcpy folder of the package, and in the file wrappers.cpp.
 
-As you can see in this [example](https://github.com/intelligent-soft-robots/context/blob/master/srcpy/wrappers.cpp), creating binders for c++ classes can be trivial.
+As you can see in this [example](https://github.com/intelligent-soft-robots/context/blob/master/srcpy/wrappers.cpp), creating binders for C++ classes can be trivial.
 
 For example, this wrapper code:
 
@@ -192,7 +192,7 @@ Note that in the [wrappers.cpp](https://github.com/intelligent-soft-robots/conte
 PYBIND11_MODULE(context, m)
 ```
 
-The above results in the creation of the python package "context", which can be used after compilation and sourcing of the workspace, simply in a terminal:
+The above results in the creation of the Python package "context", which can be used after compilation and sourcing of the workspace, simply in a terminal:
 
 ```bash
 python
@@ -204,7 +204,7 @@ then:
 import context
 ```
 
-## Unit-tests
+## Unit tests
 
 We use google tests for unit tests. See the [tests folder](https://github.com/intelligent-soft-robots/context/tree/master/tests) of the context package for a simple example to follow.
 

--- a/E2_guidelines.md
+++ b/E2_guidelines.md
@@ -32,7 +32,7 @@ When a demo requires code from various repositories, they can be hosted in a ded
 
 ### Documentation
 
-#### Code Documentation
+#### Code documentation
 
 All code shall be documented in-source.  This means that every function, class,
 struct, global variable, etc., needs to have a docstring/comment containing some
@@ -55,13 +55,13 @@ See [this file](https://github.com/intelligent-soft-robots/o80/blob/master/inclu
 for an example in C++.  Our code base currently does not have enough
 documentation, please help us doing better!
 
-#### Package Documentation
+#### Package documentation
 
 More general documentation of a package (e.g. describing how to run the software
 on the robot) can be written in separate reStructuredText-files that are stored
 in a folder `doc/` inside the package.
 
-#### Build the Documentation
+#### Build the documentation
 
 If you are using CMake, the package may include the `mpi_cmake_modules` package
 and in the CMakeLists.txt file call the `add_documentation()` macro.  The
@@ -73,7 +73,7 @@ Once built, the documentation can then be found in
 `build/package_name/share/docs/sphinx/html`.
 
 
-### Code Style Guide
+### Code style guide
 
 #### Formatting
 
@@ -98,7 +98,7 @@ installed via `pip install black`):
 black path/to/file_or_folder
 ```
 
-#### Naming Conventions
+#### Naming conventions
 
 Give as descriptive a name as possible, within reason. Do not worry about saving
 horizontal space as it is far more important to make your code immediately
@@ -121,7 +121,7 @@ Formatting of names should be as follows:
     g_, i.e. `g_variable_name`.
 
 
-##### Add Units to Variable Names
+##### Add units to variable names
 
 Variables that hold values of a specific unit should have that unit appended to
 the name.  For example if a variable holds the velocity of a motor in *krpm* it
@@ -132,7 +132,7 @@ should be called `velocity_krpm` instead of just `velocity`. Some more examples:
 - `acceleration_mps2` (m/s^2)
 
 
-#### Python-Specific Guidelines
+#### Python specific guidelines
 
 - Follow [PEP 8](https://www.python.org/dev/peps/pep-0008/).
   - Exception: For the line length we use Black's default of 88 characters.  If
@@ -151,9 +151,9 @@ should be called `velocity_krpm` instead of just `velocity`. Some more examples:
       ignore=E203,W503
 
 
-#### C++-Specific Guidelines
+#### C++ specific guidelines
 
-##### Folder Structure and File Naming
+##### Folder tructure and file naming
 
 General folder structure of a package with C++ code:
 
@@ -210,7 +210,7 @@ void foobar(Foo foo);  // results in copy of `foo`. Only do this if there is a
                        // specific need for it.
 ```
 
-##### pragma once vs Include Guards
+##### pragma once vs include guards
 
 Prefer `#pragma once` over include guards.  `#pragma once` is not part of the
 official standard but is widely supported by compilers and much easier to

--- a/E3_packages_overview.md
+++ b/E3_packages_overview.md
@@ -1,4 +1,4 @@
-# Developer's guide 3: packages overview
+# Developer's guide 3: Packages overview
 
 
 The software for the control of the PAM robot (real or mujoco simulated) is splitted over several packages.

--- a/E4_advanced_overview.md
+++ b/E4_advanced_overview.md
@@ -1,9 +1,9 @@
-# Developer's guide 4: advanced overview
+# Developer's guide 4: Advanced overview
 
 This page is a good read for anybody who would like to have a better understanding on how the software works "under the hood".
 
 
-## mujoco model xml file
+## MuJoCo model XML file
 
 For Mujoco to work,  model xml file that describes the robot and environment is needed.
 Possibly, this xml file can be created "by hand".
@@ -17,7 +17,7 @@ https://github.com/intelligent-soft-robots/pam_demos/blob/main/tutorial_4_backen
 
 which will generate one in a folder of /tmp/
 
-## mujoco controller
+## MuJoCo controller
 
 A controller is a piece of software that is called at each iteration of mujoco, and can modify mujoco's global variables.
 Mujoco has a global variable "mjcb_control" which is a pointer to a controller function. The user can set this pointer to the function of its choice, and this function will be called at each iteration.
@@ -110,8 +110,8 @@ the xml file is generated and the controllers are added.
 
 ## C++ and Python
 
-In the above, some code is in c++, so other code is in python.
-It works because python encapsulate the c++ code, here:
+In the above, some code is in C++, so other code is in Python.
+It works because Python encapsulate the C++ code, here:
 
 - https://github.com/intelligent-soft-robots/pam_mujoco/blob/master/srcpy/wrappers.cpp
 

--- a/E5_documentation.md
+++ b/E5_documentation.md
@@ -1,14 +1,14 @@
-# Developer's guide: updating the documentation
+# Developer's guide: Updating the documentation
 
 Everybody is welcome to update/extend the documentation.
 
 For doing so:
 
-- clone the documentation [repository](https://github.com/intelligent-soft-robots/pam_documentation)
-- update the documentation
-- If you add a new file: list it in the file index.rst (at the right place, are files are in order)
-- If you add a new file: note that both RST files and MD files are supported. 
-- Check the documentation looks nice locally: you can generate the html files with ```make html``` (see requirements.txt).
-- push to a branch and perform a pull request to the main branch.
+1. Clone the documentation [repository](https://github.com/intelligent-soft-robots/pam_documentation)
+2. Update the documentation
+3. If you add a new file: list it in the file index.rst (at the right place, are files are in order)
+4. If you add a new file: note that both RST files and MD files are supported. 
+5. Check the documentation looks nice locally: you can generate the html files with ```make html``` (see requirements.txt).
+6. Push to a branch and perform a pull request to the main branch.
 
 After review and once the branch is merged into th main branch, the online documentation will be automatically updated.


### PR DESCRIPTION
## Description
Update to documentation by unifying capitalization of headings and some key words like e.g. "Python", "C++", "MuJoCo", "PAM".
Important information got highlighted using markdown-elements (see "More info: Using real robot").
In a few cases a small rephrasing has been done.
If another site of the documentation has been referenced, a linkage has been added.

## How I Tested
HTML has been generated with Sphinx and inspected on Firefox and Chromium. 

## Remark
I rebased multiple commits and also merged main with the branch to resolve merge conflicts. I double checked that the previous commit history is untouched. However, I would appreciate if the reviewer can give me a small feedback if rebasing and merging was done properly.