### PR TITLE
Minor fixes: install path and ball tracking example

### DIFF
--- a/A1_overview_and_installation.md
+++ b/A1_overview_and_installation.md
@@ -131,7 +131,7 @@ This will result in a "install" folder containing the compiled binaries
 In each new terminal, the workspace needs to be sourced:
 
 ```bash
-source /path/to/Software/install/setup.bash
+source /path/to/Software/workspace/install/setup.bash
 ```
 ```{note}
 Possibly, you may want to add the line above to the ~/.bashrc file (so that each new terminal source the workspace automatically).

--- a/C5_visual_ball_tracking.md
+++ b/C5_visual_ball_tracking.md
@@ -63,7 +63,7 @@ import tennicam_client
 TENNICAM_CLIENT_DEFAULT_SEGMENT_ID = "tennicam_client"
 
 frontend = tennicam_client.FrontEnd(TENNICAM_CLIENT_DEFAULT_SEGMENT_ID)
-obs = frontend.read(iteration)
+obs = frontend.latest()
 ball = obs.get()
 print(ball.to_string())
 

--- a/E5_documentation.md
+++ b/E5_documentation.md
@@ -37,7 +37,7 @@ For this to work, you may need to pip install some packages: m2r, mistune (versi
 Once compilation is successfully finished, html documentation can be found in paths:
 
 ```
-/path/to/software/install/<package name>/share/<package name>/docs/
+/path/to/Software/workspace/install/<package name>/share/<package name>/docs/
 ```
 
 ### How to have the documentation building for a package

--- a/E5_documentation.md
+++ b/E5_documentation.md
@@ -14,7 +14,7 @@ For doing so:
 5. Check the documentation looks nice locally: you can generate the html files with ```make html``` (see requirements.txt).
 6. Push to a branch and perform a pull request to the main branch.
 
-After review and once the branch is merged into th main branch, the online documentation will be automatically updated.
+After review and once the branch is merged into the main branch, the online documentation will be automatically updated.
 
 ## Documentation of all packages
 


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

Fixes two minor issues that I found while using the documentation.
1. The path to the install directory is wrong (`/path/to/Software/install` instead of `/path/to/Software/workspace/install`)
2. The ball tracking example is not runnable (the `iteration` variable is undefined)
