### PR TITLE
Update dependencies to fix compatibility issue

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -71,7 +71,7 @@ release = "1.0.0"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sphinx-rtd-theme==1.0.0
-myst-parser==0.15.2
+sphinx-rtd-theme>=2.0.0,<2.1
+myst-parser>=2.0.0,<2.1


### PR DESCRIPTION
## Description

Upgrades the `sphinx-rtd-theme` and `myst-parser` packages to fix an incompatibility issue during the compilation of the docs (the `sphinxcontrib.applehelp` extension depends on Sphinx version >= 5 but `myst-parser` requires Sphinx version < 5).